### PR TITLE
Render User-Input Estimation as Card Badges with Categorized Colors

### DIFF
--- a/public/import-csv.html
+++ b/public/import-csv.html
@@ -10,6 +10,9 @@
       <p>Select a CSV file to create cards on your board.</p>
       <input type="file" id="csvFileInput" accept=".csv" />
       <button id="uploadButton">Upload</button>
+      <h2>Parsed Data</h2>
+      <div id="parsedDataContainer"></div>
+      <button id="createCardsButton" style="display:none;">Create Cards</button>
       <script src="./js/import_csv.js"></script>
     </div>
   </body>

--- a/public/js/client.js
+++ b/public/js/client.js
@@ -2,7 +2,7 @@
 
 var Promise = TrelloPowerUp.Promise;
 
-// this is a temp icon, it doesn't render currently
+// This is a temp icon, it doesn't render currently
 var WHITE_ICON = 'https://cdn.hyperdev.com/us-east-1%3A3d31b21c-01a0-4da2-8827-4bc6e88b7618%2Ficon-white.svg';
 
 var boardButtonCallback = function (t) {
@@ -26,6 +26,8 @@ var boardButtonCallback = function (t) {
   });
 };
 
+// This is the core part of the Power-Up where different features 
+// (buttons, badges, authorization) are registered.
 TrelloPowerUp.initialize(
   {
     'board-buttons': function (t, options) {
@@ -46,22 +48,45 @@ TrelloPowerUp.initialize(
         },
       ];
     },
-    'card-badges': function (t, options) {
-      return t.get('card', 'shared', 'estimate')
-      .then(function(estimate) {
+    "card-badges": function (t, options) {
+      return t.card('id', 'desc')
+      .then(function (card) {
+        // Extract estimate from description
+        const estimateMatch = card.desc.match(/\[(.*?)\]/);
+        const estimate = estimateMatch ? estimateMatch[1].toLowerCase() : 'N/A';
+
+
+        // Define color mapping based on estimate size
+        const estimateColors = {
+            "x-small": 'green',
+            "small": 'green',
+            "medium": 'orange',
+            "large": 'red',
+            "x-large": 'red'
+          };
+
         return [{
-          title: 'Estimate',
-          text: estimate || 'No Estimate!',
-          color: estimate ? null : 'red',
-          callback: function(t) {
-            return t.popup({
-              title: "Estimation",
-              url: 'estimate.html',
-            });
-          }
-        }]
+          text: `${estimate}`,
+          color: estimateColors[`${estimate}`] || 'blue'
+        }];
       });
     },
+    // 'card-badges': function (t, options) {
+    //   return t.get('card', 'shared', 'estimate')
+    //   .then(function(estimate) {
+    //     return [{
+    //       title: 'Estimate',
+    //       text: estimate || 'No Estimate!',
+    //       color: estimate ? null : 'red',
+    //       callback: function(t) {
+    //         return t.popup({
+    //           title: "Estimation",
+    //           url: 'estimate.html',
+    //         });
+    //       }
+    //     }]
+    //   });
+    // },
     'card-buttons': function(t, options){
       return [{
         text: 'Estimate Size',

--- a/public/js/import_csv.js
+++ b/public/js/import_csv.js
@@ -2,7 +2,7 @@ const t = window.TrelloPowerUp.iframe();
 
 // Operations after upload button is clicked
 document.getElementById("uploadButton").addEventListener("click", function () {
-  alert("button clicked");
+  // alert("button clicked");
   const fileInput = document.getElementById("csvFileInput");
   const file = fileInput.files[0];
   if (!file) {
@@ -18,8 +18,21 @@ document.getElementById("uploadButton").addEventListener("click", function () {
   reader.readAsText(file);
 });
 
+function getSelectedSizes() {
+  const selectedData = [];
+  document.querySelectorAll(".estimateSize").forEach((select, index) => {
+      const row = select.closest("tr");
+      const title = row.cells[0].textContent;
+      const description = row.cells[1].textContent;
+      const selectedValue = select.value;
+      console.log(`------Row ${index + 1}: "${title}" selected size: ${selectedValue}`);
+      selectedData.push([title, description, selectedValue]);
+  });
+  return selectedData;
+}
+
 function parseCSV(csvContent) {
-  alert("parsing CSV");
+  // alert("parsing CSV");
 
   const rows = csvContent.split("\n").map((row) => row.split(","));
   const headers = rows[0]; // Assuming the first row contains headers
@@ -31,8 +44,67 @@ function parseCSV(csvContent) {
   console.log("Data:", data);
 
   // Now handle the CSV data, e.g., create Trello cards
-  createCardsFromCSVData(data);
+  // createCardsFromCSVData(data);
+  displayParsedData(data)
+
+  // var dataWithSize;
+
+  //after data table displayed, create cards button stand by
+  document.getElementById("createCardsButton").addEventListener("click", () => {
+    console.log("Hi!");
+    const dataWithSize = getSelectedSizes();
+    console.log("DataWithSize: ", dataWithSize);
+    createCardsFromCSVData(dataWithSize);
+  });
+  
+  // document.getElementById("createCardsButton").addEventListener("click", function () {
+  //   createCardsFromCSVData(dataWithSize);
+  // });
+
 }
+
+
+
+function displayParsedData(data) {
+  // alert("Start display data");
+  const container = document.getElementById("parsedDataContainer");
+  container.innerHTML = "";
+  
+  const table = document.createElement("table");
+  table.innerHTML = `
+    <tr>
+      <th>Title</th>
+      <th>Description</th>
+      <th>Estimate</th>
+    </tr>
+  `;
+
+  data.forEach((row, index) => {
+    const title = row[0]?.trim() || "Untitled";
+    const description = row[1]?.trim() || "No description";
+    
+    const tr = document.createElement("tr");
+    tr.innerHTML = `
+      <td>${title}</td>
+      <td>${description}</td>
+      <td>
+        <select name="size" class="estimateSize">
+          <option value="x-small">X-Small</option>
+          <option value="small">Small</option>
+          <option value="medium">Medium</option>
+          <option value="large">Large</option>
+          <option value="x-large">X-Large</option>
+        </select>
+      </td>
+    `;
+    table.appendChild(tr);
+  });
+
+  container.appendChild(table);
+  document.getElementById("createCardsButton").style.display = "block";
+  alert("Table, Create-Card Button created");
+}
+
 
 // updated function for rendering cards
 function createCardsFromCSVData(data) {
@@ -45,13 +117,13 @@ function createCardsFromCSVData(data) {
     data.forEach((row) => {
       const title = row[0]?.trim();
       const description = row[1]?.trim();
+      const estimateSize = row[2]?.trim();
 
       if (!title) return; // Skip empty rows
 
       // Replace with your Trello API credentials (store them securely)
       const apiKey = "";
       const apiToken = "";
-
       // Example: Get first list in the board to add the card to
       console.log(`Creating new card for: ${title}`);
       fetch(`https://api.trello.com/1/boards/${boardId}/lists?key=${apiKey}&token=${apiToken}`) //This makes a request to Trello's API.
@@ -63,14 +135,15 @@ function createCardsFromCSVData(data) {
           }
 
           const listId = lists[0].id; // Default add to the first list on the board
-
+          const descriptionWithSize =  "[" + estimateSize + "] " + description
           // Making create-card request using values of title and description 
-          const url = `https://api.trello.com/1/cards?key=${apiKey}&token=${apiToken}&idList=${listId}&name=${encodeURIComponent(title)}&desc=${encodeURIComponent(description)}`;
+          const url = `https://api.trello.com/1/cards?key=${apiKey}&token=${apiToken}&idList=${listId}&name=${encodeURIComponent(title)}&desc=${encodeURIComponent(descriptionWithSize)}`;
 
           fetch(url, { method: "POST" }) // send POST request to create something (card)
             .then(response => response.json())
             .then(card => {
               console.log("Created card:", card);
+              // updateCustomField(apiKey, apiToken, card.id, "yourCustomFieldId", "Your Custom Value");
             })
             .catch(err => console.error("Error creating card:", err));
         })


### PR DESCRIPTION

**Summary**
This PR enhances the Trello Power-Up by dynamically rendering user-provided estimations as card badges. The badges now display color-coded categories based on the estimation value.

**Changes Implemented**
Extracted estimation values from the card description using regex (/\[(.*?)\]/).
Implemented a color mapping for estimates:
Green for "x-small", "small".
Orange for "medium".
Red for "large", "x-large".
Updated the "card-badges" function to apply the appropriate color based on the extracted estimate.
Ensured graceful handling when no estimate is found (defaults to "N/A").

**How to Test**
1. Go to shared Trello board: https://trello.com/b/N96bNkKi/power-up-testing
2. Import a csv file with correct format -- two columns "Title" and "Description", sample csv can be found here under public > test_csvs
3. Select desired estimation for each row of data imported
4. Observe the corresponding badge color based on the estimation value.
